### PR TITLE
Add intltool to depends

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Make sure you have the following dependencies installed:
 * *gnome-common*,
 * *autoconf*,
 * *automake*,
-* *gnome-tweak-tool*.
+* *gnome-tweak-tool*,
+* *intltool*.
 
 Run the following commands:
 


### PR DESCRIPTION
`intltool` was needed to be installed on arch.