### PR TITLE
Fix Russian language code

### DIFF
--- a/po/LINGUAS
+++ b/po/LINGUAS
@@ -1,6 +1,6 @@
-zh_CN
-pt_BR
-pl
 de
 es
-ru_RU
+pl
+pt_BR
+ru
+zh_CN

--- a/po/ru.po
+++ b/po/ru.po
@@ -18,7 +18,7 @@ msgstr ""
 "Last-Translator: Alex Gluck <alexgluck@bk.ru>\n"
 "Plural-Forms: nplurals=3; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<10 || n%100>=20) ? 1 : 2);\n"
-"Language: ru_RU\n"
+"Language: ru\n"
 
 #: src/extension.js:119
 msgid ""


### PR DESCRIPTION
_RU is redundant, and breaks using the translation with any other ru_XX locale.